### PR TITLE
√の場合に右側を入力不可に修正 #4

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
         }
         function disableSecond(){
             const op = document.getElementById('operator').value;
-            // if(op === 'sqrt' || op === 'square'){
-            if(op === 'square'){
+            if(op === 'sqrt' || op === 'square'){
+            //if(op === 'square'){
                 document.getElementById('second').disabled = true
             }
             else{


### PR DESCRIPTION
## 変更後の振る舞い
√を選択した場合に右側の入力エリアが入力不可になる

## 変更前の振る舞い
√を選択した場合でも右側の入力エリアが入力できる
